### PR TITLE
v1.9: Dynamic discovery of Trackpoint path

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -100,4 +100,7 @@
     + Update template with current settings at start and on setting (Option 2) to prevent settings being undone when setting persistence (Option 3)
   - v1.8.5
     + Throw error if user attempts to disable persistence if it's not enabled
-    + Apply current settings upon disabling persistence (to prevent setting changes)                                            
+    + Apply current settings upon disabling persistence (to prevent setting changes)    
+##### v1.9.0
+  + Change Trackpoint configuration directory assignment to dynamic discovery instead of hard-coded conditional paths
+  + Remove conditional path existence check in trackpoint.service since it's redundant given the check in trackpoint.sh

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ This can be useful for understanding what pkf_trackpoint is doing as well as ass
 
 ## Files created/modified
   - Files restored every boot (do not delete)
-    + /sys/devices/platform/i8042/serio1/serio2/sensitivity
-    + /sys/devices/platform/i8042/serio1/serio2/speed
-    + /sys/devices/platform/i8042/serio1/serio2/press_to_select
+    + /sys/devices/<...>/sensitivity
+    + /sys/devices/<...>/speed
+    + /sys/devices/<...>/press_to_select
   - Files that remain between reboots (if using persistent settings)
     + /etc/systemd/system/trackpoint.service (systemd)
     + /etc/systemd/system/trackpoint.timer (systemd)
@@ -46,6 +46,8 @@ This can be useful for understanding what pkf_trackpoint is doing as well as ass
   - 200: Trackpoint not detected (or at least common Trackpoint sys directories do not appear to exist.)
 
 ## Variables used
+  - file = temporary variable used in FOR loop to capture locations of files named "press_to_select" located in /sys/devices directory
+  - dir = temporary variable used in FOR lop to capture the parent directory of each $file found
   - vTrackpointPath = Path to Trackpoint settings. Varies based on existence of a trackpad ( sys/devices/platform/i8042/serio1 | sys/devices/platform/i8042/serio1/serio2 )
   - vInitSystem = Detected initialization service used ( sysv | systemd )
   - vInitStatus = Current status of persistence ( Enabled | Disabled | Broken. Use Option 3 or 5)

--- a/pkf_trackpoint.sh
+++ b/pkf_trackpoint.sh
@@ -7,20 +7,19 @@ if ! [ $(id -u) = 0 ]; then
 fi
 
 ## Determine and set correct path for trackpoint
-if [ -f /sys/devices/platform/i8042/serio1/serio2/sensitivity ];
-then
-  vTrackpointPath=/sys/devices/platform/i8042/serio1/serio2
-elif [ -f /sys/devices/platform/i8042/serio1/sensitivity ];
-then
-  vTrackpointPath=/sys/devices/platform/i8042/serio1
-elif [ -f /sys/devices/rmi4-00/rmi4-00.fn03/serio2/sensitivity ];
-then
-  vTrackpointPath=/sys/devices/rmi4-00/rmi4-00.fn03/serio2
-else
+for file in $(find /sys/devices -name press_to_select)
+do
+  dir=$(dirname $file)
+  if [ -f $dir/speed -a -f $dir/sensitivity ]; then
+    vTrackpointPath=$dir
+    break
+  fi
+done
+
+if ! [ $vTrackpointPath ]; then
   echo "Trackpoint not detected"
   exit 200
 fi
-
 
 ## Initialize trackpoint varialbes with current values
 vSensitivity=$(<$vTrackpointPath/sensitivity)

--- a/templates/trackpoint.service
+++ b/templates/trackpoint.service
@@ -1,9 +1,5 @@
 [Unit]
 Description=Trackpoint Configuration for systemd
-## Only using "sensitivity" file as also using "speed" and "press" would be redundant
-ConditionPathExists=|/sys/devices/platform/i8042/serio1/serio2/sensitivity
-ConditionPathExists=|/sys/devices/platform/i8042/serio1/sensitivity
-ConditionPathExists=|/sys/devices/rmi4-00/rmi4-00.fn03/serio2/sensitivity
 
 [Service]
 Type=oneshot

--- a/templates/trackpoint.sh
+++ b/templates/trackpoint.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 ## Determine and set correct path for trackpoint
-if [ -f /sys/devices/platform/i8042/serio1/serio2/sensitivity ];
-then
-  vTrackpointPath=/sys/devices/platform/i8042/serio1/serio2
-elif [ -f /sys/devices/platform/i8042/serio1/sensitivity ];
-then
-  vTrackpointPath=/sys/devices/platform/i8042/serio1
-elif [ -f /sys/devices/rmi4-00/rmi4-00.fn03/serio2/sensitivity ];
-then
-  vTrackpointPath=/sys/devices/rmi4-00/rmi4-00.fn03/serio2
-else
+for file in $(find /sys/devices -name press_to_select)
+do
+  dir=$(dirname $file)
+  if [ -f $dir/speed -a -f $dir/sensitivity ]; then
+    vTrackpointPath=$dir
+    break
+  fi
+done
+
+if ! [ $vTrackpointPath ]; then
   echo "Trackpoint not detected"
   exit 200
 fi


### PR DESCRIPTION
- Change Trackpoint configuration directory assignment to dynamic discovery instead of hard-coded conditional paths

- Remove conditional path existence check in trackpoint.service since it's redundant given the check in trackpoint.sh